### PR TITLE
Fix broken 'current_currency' override

### DIFF
--- a/lib/spree/core/controller_helpers/common_decorator.rb
+++ b/lib/spree/core/controller_helpers/common_decorator.rb
@@ -1,4 +1,4 @@
-Spree::Core::ControllerHelpers::Common.class_eval do
+Spree::Core::ControllerHelpers::Order.class_eval do
   def current_currency
     # ensure session currency is supported
     #


### PR DESCRIPTION
This fixes the broken 'current_currency' helper caused by the following commit in Spree spree/spree@1dd787fcaa23901d2c4476fe33af648f87f1b636

This patch shifts the 'current_currency' method override to Spree::Core::ControllerHelpers::Order

After updating Spree with the aforementioned commit, I had issues with 'current_currency' returning only the default currency from Spree::Config instead of the selected/set currency this gem provides.

I came across it originally because it is breaking 1-3-stable as well (spree/spree@11df34ada818b9034e95f16e0f691d5c09dd8776)
