### PR TITLE
Currency selector should now work on 1-3-stable

### DIFF
--- a/lib/spree/core/controller_helpers/common_decorator.rb
+++ b/lib/spree/core/controller_helpers/common_decorator.rb
@@ -1,8 +1,8 @@
-Spree::Core::ControllerHelpers::Common.class_eval do
+Spree::Core::ControllerHelpers::Order.class_eval do
   def current_currency
     # ensure session currency is supported
     #
-    if session.key?(:currency)# && supported_currencies.map(&:iso_code).include?(session[:currency])
+    if session.key?(:currency) && supported_currencies.map(&:iso_code).include?(session[:currency])
       session[:currency]
     else
       Spree::Config[:currency]


### PR DESCRIPTION
It looks like the current_currency method was moved in 1-3-stable so I have updated the decorator to reflect this.
