### PR TITLE
Display price without currency symbol in text input

### DIFF
--- a/app/views/spree/admin/prices/_variant_prices.html.erb
+++ b/app/views/spree/admin/prices/_variant_prices.html.erb
@@ -3,7 +3,7 @@
 <% supported_currencies.each do |currency| %>
   <li>
     <% price = variant.price_in(currency.iso_code) %>
-    <%= text_field_tag("vp[#{variant.id}][#{currency.iso_code}]", (price ? price.display_amount : '')) %>
+    <%= text_field_tag("vp[#{variant.id}][#{currency.iso_code}]", (price ? price.display_amount.money : '')) %>
     <%= currency.iso_code %>
   </li>
 <% end %>


### PR DESCRIPTION
The currency ISO code is displayed next to the text input anyway, so we don't need currency symbol too.
