### PR TITLE
added automatic currency conversions

### DIFF
--- a/app/assets/javascripts/admin/spree_multi_currency.js
+++ b/app/assets/javascripts/admin/spree_multi_currency.js
@@ -1,1 +1,11 @@
 //= require admin/spree_backend
+
+
+$(function() {
+  $(".set-currency-price-manually").change(function() { 
+    $(this).prev("input").prop('disabled', $(this).is(":checked")).focus();
+    return false;
+  });
+  
+  $(".set-currency-price-manually").trigger('change');
+});

--- a/app/assets/javascripts/store/currency.js.coffee
+++ b/app/assets/javascripts/store/currency.js.coffee
@@ -1,8 +1,8 @@
 $ ->
-  $('#currency-select select').change ->
+  $("#currency-select select").change ->
     $.ajax(
-      type: 'POST'
-      url: $(this).data('href')
+      type: "POST"
+      url: $(this).data("href")
       data:
         currency: $(this).val()
     ).done ->

--- a/app/controllers/spree/admin/prices_controller.rb
+++ b/app/controllers/spree/admin/prices_controller.rb
@@ -6,16 +6,27 @@ module Spree
       def create
         params[:vp].each do |variant_id, prices|
           variant = Spree::Variant.find(variant_id)
+          base_currency = Spree::Config[:currency]
+          base_price = prices[base_currency][:price].to_money(base_currency)
+          
           if variant
             supported_currencies.each do |currency|
               price = variant.price_in(currency.iso_code)
-              price.price = (prices[currency.iso_code].blank? ? nil : prices[currency.iso_code])
+              price.preferred_auto_update = currency == base_currency ? false : prices[currency.iso_code][:auto_update]
+              
+              if price.preferred_auto_update
+                price.price = base_price.exchange_to(currency.iso_code)
+              else
+                price.price = (prices[currency.iso_code].blank? ? nil : prices[currency.iso_code][:price])
+              end
+
               price.save! if price.changed?
             end
           end
         end
         render :action => :index
       end
+      
     end
   end
 end

--- a/app/models/spree/price_decorator.rb
+++ b/app/models/spree/price_decorator.rb
@@ -1,0 +1,3 @@
+Spree::Price.class_eval do
+  preference :auto_update, :boolean, :default => false
+end

--- a/app/views/spree/admin/prices/_variant_prices.html.erb
+++ b/app/views/spree/admin/prices/_variant_prices.html.erb
@@ -3,8 +3,14 @@
 <% supported_currencies.each do |currency| %>
   <li>
     <% price = variant.price_in(currency.iso_code) %>
-    <%= text_field_tag("vp[#{variant.id}][#{currency.iso_code}]", (price ? price.display_amount.money : '')) %>
+    <%= text_field_tag("vp[#{variant.id}][#{currency.iso_code}][price]", (price ? price.display_amount.money : '') ) %>
     <%= currency.iso_code %>
+    <% unless currency == Spree::Config[:currency] %>
+      (
+        <%= check_box_tag("vp[#{variant.id}][#{currency.iso_code}][auto_update]", 1, price.prefers_auto_update?, class: 'set-currency-price-manually')  %>
+        <%= content_tag :span, 'set automatically?', id: 'hint'%>
+      )
+    <% end %>
   </li>
 <% end %>
 </ul>

--- a/config/initializers/spree_multi_currency.rb
+++ b/config/initializers/spree_multi_currency.rb
@@ -1,0 +1,2 @@
+Money::Bank::GoogleCurrency.ttl_in_seconds = 86400
+Money.default_bank = Money::Bank::GoogleCurrency.new

--- a/lib/spree_multi_currency/engine.rb
+++ b/lib/spree_multi_currency/engine.rb
@@ -1,6 +1,9 @@
 module SpreeMultiCurrency
   class Engine < Rails::Engine
     require 'spree/core'
+    require 'money'
+    require 'money/bank/google_currency'
+    
     isolate_namespace Spree
     engine_name 'spree_multi_currency'
 

--- a/spree_multi_currency.gemspec
+++ b/spree_multi_currency.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', spree_version
   s.add_dependency 'spree_frontend', spree_version
   s.add_dependency 'spree_backend', spree_version
+  s.add_dependency 'money' , ' ~> 6.0.0'
+  s.add_dependency 'google_currency'
 
   s.add_development_dependency 'capybara', '1.0.1'
   s.add_development_dependency 'factory_girl', '~> 2.6.4'


### PR DESCRIPTION
Added automatic conversion from base currency to other supported currencies. Automatic conversions can be enabled/disabled per variant/currency combination.

Uses money gem and GoogleCurrency as the default bank (can be overridden in an initializer)
