### PR TITLE
General settings compatible changes

### DIFF
--- a/app/controllers/spree/admin/general_settings_controller_decorator.rb
+++ b/app/controllers/spree/admin/general_settings_controller_decorator.rb
@@ -1,19 +1,19 @@
 Spree::Admin::GeneralSettingsController.class_eval do
+  before_filter :update_currency_settings, only: :update
+
   def render *args
     @preferences_currency |= [:allow_currency_change, :show_currency_selector, :supported_currencies]
     super
   end
 
-  def update
-    params.each do |name, value|
-      next unless Spree::Config.has_preference? name
-      if name == "supported_currencies"
-        value = value.split(',').map { |curr| ::Money::Currency.find(curr.strip).try(:iso_code) }.concat([Spree::Config[:currency]]).uniq.compact.join(',')
+  private
+    def update_currency_settings
+      params.each do |name, value|
+        next unless Spree::Config.has_preference? name
+        if name == "supported_currencies"
+          value = value.split(',').map { |curr| ::Money::Currency.find(curr.strip).try(:iso_code) }.concat([Spree::Config[:currency]]).uniq.compact.join(',')
+        end
+        Spree::Config[name] = value
       end
-      Spree::Config[name] = value
-    end
-    flash[:success] = t(:successfully_updated, :resource => t(:general_settings))
-
-    redirect_to edit_admin_general_settings_path
   end
 end


### PR DESCRIPTION
The update earlier used to override the "real" admin general settings.No matter what you wrote on those fields at the General Settings form input,those were never reflected/stored in the database.With this change,those values would be properly stored.
