### PR TITLE
Strip Currency Iso Codes

### DIFF
--- a/lib/spree/core/currency_helpers.rb
+++ b/lib/spree/core/currency_helpers.rb
@@ -5,7 +5,7 @@ module Spree
     end
 
     def supported_currencies
-      Spree::Config[:supported_currencies].split(',').map { |code| ::Money::Currency.find(code) }
+      Spree::Config[:supported_currencies].split(',').map { |code| ::Money::Currency.find(code.strip) }
     end
   end
 end


### PR DESCRIPTION
Comma separated lists should allow whitespaces.
