### PR TITLE
2.4 cleanup, mostly cosmetic

### DIFF
--- a/app/controllers/spree/admin/prices_controller.rb
+++ b/app/controllers/spree/admin/prices_controller.rb
@@ -10,7 +10,7 @@ module Spree
           supported_currencies.each do |currency|
             price = variant.price_in(currency.iso_code)
             price.price = (prices[currency.iso_code].blank? ? nil : prices[currency.iso_code].to_money)
-            price.save! if price.changed?
+            price.save! if price.new_record? && price.price || !price.new_record? && price.changed?
           end
         end
         flash[:success] = Spree.t('notice.prices_saved')

--- a/app/overrides/spree/admin/shared/_product_tabs/prices.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/prices.html.erb.deface
@@ -1,4 +1,4 @@
-<!-- insert_bottom 'ul[data-hook="admin_product_tabs"]' -->
+<!-- insert_bottom 'ul[data-hook="admin_product_tabs"]' original '8f75b3b60c69e80cac977160642f9cd6ed4d8b68' -->
 <li<%== ' class="active"' if current == 'Prices' %>>
   <%= link_to_with_icon 'icon-money', Spree.t(:Prices), admin_product_prices_url(@product) %>
 </li>

--- a/app/overrides/spree/admin/shared/_product_tabs/prices.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/prices.html.erb.deface
@@ -1,4 +1,4 @@
 <!-- insert_bottom 'ul[data-hook="admin_product_tabs"]' original '8f75b3b60c69e80cac977160642f9cd6ed4d8b68' -->
 <li<%== ' class="active"' if current == 'Prices' %>>
-  <%= link_to_with_icon 'icon-money', Spree.t(:Prices), admin_product_prices_url(@product) %>
+  <%= link_to_with_icon 'money', Spree.t(:Prices), admin_product_prices_url(@product) %>
 </li>

--- a/app/overrides/spree/shared/_main_nav_bar/currency_selector.html.erb.deface
+++ b/app/overrides/spree/shared/_main_nav_bar/currency_selector.html.erb.deface
@@ -1,4 +1,4 @@
-<!-- insert_bottom '#main-nav-bar' -->
+<!-- insert_bottom '#main-nav-bar' original '838e211947e51dd9e5056f685103c00b2094c5d2' -->
 <% if Spree::Config[:allow_currency_change] && Spree::Config[:show_currency_selector] && supported_currencies.size > 1 %>
   <li id="currency-select" style="float: right; margin-right: 10px;" data-hook>
     <%= form_tag(set_currency_path(format: :html)) do %>

--- a/app/views/spree/admin/prices/_variant_prices.html.erb
+++ b/app/views/spree/admin/prices/_variant_prices.html.erb
@@ -1,10 +1,10 @@
-<h5><%= variant.sku %> (<%= variant.is_master? ? Spree.t(:master) : variant.options_text %>)</h5>
-<div class="omega two columns">
-<% supported_currencies.each do |currency| %>
-  <% price = variant.price_in(currency.iso_code) %>
-  <div class="field">
-    <%= label_tag "vp[#{variant.id}][#{currency.iso_code}]", currency.iso_code %>
-    <%= text_field_tag("vp[#{variant.id}][#{currency.iso_code}]", (price ? price.display_amount.money : '')) %>
-  </div>
-<% end %>
+<div class="omega six columns">
+  <h5><%= variant.sku %> (<%= variant.is_master? ? Spree.t(:master) : variant.options_text %>)</h5>
+  <% supported_currencies.each do |currency| %>
+    <% price = variant.price_in(currency.iso_code) %>
+    <div class="field">
+      <%= label_tag "vp[#{variant.id}][#{currency.iso_code}]", currency.iso_code %>
+      <%= text_field_tag("vp[#{variant.id}][#{currency.iso_code}]", (price ? price.display_amount.money : '')) %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/spree/admin/prices/_variant_prices.html.erb
+++ b/app/views/spree/admin/prices/_variant_prices.html.erb
@@ -4,7 +4,7 @@
     <% price = variant.price_in(currency.iso_code) %>
     <div class="field">
       <%= label_tag "vp[#{variant.id}][#{currency.iso_code}]", currency.iso_code %>
-      <%= text_field_tag("vp[#{variant.id}][#{currency.iso_code}]", (price ? price.display_amount.money : '')) %>
+      <%= text_field_tag("vp[#{variant.id}][#{currency.iso_code}]", (price && price.price ? price.display_amount.money : '')) %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
Most of these are cosmetic:
* Fixed Issue #35 
* Added original hashes to remove warnings for overrides
* Avoid showing price of 0.00 when price is not available (instead show blank)
* Handle saving blank values (save as nil) -- previously it would save as 0.00 (which would show the item as FREE!)
* Fixed the icon for prices tab