### PR TITLE
refactor(README): show correct branch for gem in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This provides 3 preferences:
 
 Add to your `Gemfile`
 ```ruby
-gem 'spree_multi_currency', github: 'spree-contrib/spree_multi_currency', branch: 'master'
+gem 'spree_multi_currency', github: 'spree-contrib/spree_multi_currency', branch: '3-0-stable'
 ```
 
 Run

--- a/db/migrate/20150408095247_add_multi_currency_options_to_preferences.rb
+++ b/db/migrate/20150408095247_add_multi_currency_options_to_preferences.rb
@@ -1,8 +1,0 @@
-# This migration comes from spree_i18n (originally 20150224152415)
-class AddMultiCurrencyOptionsToPreferences < ActiveRecord::Migration
-  def change
-    add_column :spree_preferences, :allow_currency_change, :boolean
-    add_column :spree_preferences, :show_currency_selector, :boolean
-    add_column :spree_preferences, :supported_currencies, :string
-  end
-end

--- a/db/migrate/20150408095247_add_multi_currency_options_to_preferences.rb
+++ b/db/migrate/20150408095247_add_multi_currency_options_to_preferences.rb
@@ -1,0 +1,8 @@
+# This migration comes from spree_i18n (originally 20150224152415)
+class AddMultiCurrencyOptionsToPreferences < ActiveRecord::Migration
+  def change
+    add_column :spree_preferences, :allow_currency_change, :boolean
+    add_column :spree_preferences, :show_currency_selector, :boolean
+    add_column :spree_preferences, :supported_currencies, :string
+  end
+end


### PR DESCRIPTION
If you try to `bundle install` using the master branch, it will fail due to the `spree_core` gem dependency, which is now set to `'~> 3.1.0.beta'`.