### PR TITLE
Fix engine init callback

### DIFF
--- a/lib/spree_multi_currency/engine.rb
+++ b/lib/spree_multi_currency/engine.rb
@@ -6,7 +6,7 @@ module SpreeMultiCurrency
 
     require 'spree/core/currency_helpers'
 
-    def self.activate
+    def self.activate(app)
       ['../../app/**/*_decorator*.rb', '../../lib/**/*_decorator*.rb'].each do |path|
         Dir.glob(File.join(File.dirname(__FILE__), path)) do |c|
           Rails.configuration.cache_classes ? require(c) : load(c)
@@ -15,6 +15,6 @@ module SpreeMultiCurrency
       ApplicationController.send :include, Spree::CurrencyHelpers
     end
 
-    config.to_prepare(&method(:activate).to_proc)
+    config.before_initialize(&method(:activate).to_proc)
   end
 end


### PR DESCRIPTION
Changes the `Engine`'s `activate` method to run on `before_initialize` rather than `to_prepare` as the decorators should be loaded before `config/initializers/spree.rb`

If they are loaded after the initializers, code such as `Spree::Config[:allow_currency_change] = true` in `spree.rb` will fail due to undefined preferences.