### PR TITLE
bump version to 3.2.0.alpha

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-spree_branch = '3-1-stable'
+spree_branch = 'master'
 gem 'spree', github: 'spree/spree', branch: spree_branch
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: spree_branch
 

--- a/lib/spree_multi_currency/version.rb
+++ b/lib/spree_multi_currency/version.rb
@@ -9,9 +9,9 @@ module SpreeMultiCurrency
 
   module VERSION
     MAJOR = 3
-    MINOR = 1
+    MINOR = 2
     TINY  = 0
-    PRE   = nil
+    PRE   = 'alpha'.freeze
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
   end

--- a/spree_multi_currency.gemspec
+++ b/spree_multi_currency.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_runtime_dependency 'spree_backend', '~> 3.1.0.beta'
+  s.add_runtime_dependency 'spree_backend', '~> 3.2.0.alpha'
 
   s.add_development_dependency 'capybara', '~> 2.4.4'
   s.add_development_dependency 'poltergeist', '~> 1.6.0'


### PR DESCRIPTION
- bump version to 3.2.0.alpha
- change spree_backend dependency version to 3.2.0.alpha
- change spree branch to master