### PR TITLE
Set spree_backend to >= 3.1.0 and < 4.0 versions

### DIFF
--- a/spree_multi_currency.gemspec
+++ b/spree_multi_currency.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_runtime_dependency 'spree_backend', '~> 3.2.0.alpha'
+  s.add_runtime_dependency 'spree_backend', '>= 3.1.0', '< 4.0'
 
   s.add_development_dependency 'capybara', '~> 2.4.4'
   s.add_development_dependency 'poltergeist', '~> 1.6.0'


### PR DESCRIPTION
This PR changes the version of `spree_backend` in gemspec to point at `>= 3.1.0` and `< 4.0`.