### PR TITLE
Fix invalid checkout price issue

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -1,0 +1,10 @@
+Spree::LineItem.class_eval do
+  def update_price
+    currency_price = Spree::Price.where(
+      currency: order.currency,
+      variant_id: variant_id
+    ).first
+
+    self.price = currency_price.price_including_vat_for(tax_zone: tax_zone)
+  end
+end

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Spree::LineItem.class_eval do
   def update_price
     currency_price = Spree::Price.where(

--- a/spec/models/spree/line_item_decorator_spec.rb
+++ b/spec/models/spree/line_item_decorator_spec.rb
@@ -1,0 +1,24 @@
+describe Spree::LineItem do
+  describe 'update_price' do
+    let(:price)     { double 'price' }
+    let(:order)     { create :order, currency: 'EUR' }
+    let(:line_item) { create :line_item, order_id: order.id, currency: 'EUR' }
+
+    before do
+      expect(line_item).to receive(:variant_id).and_return(1001)
+
+      expect(Spree::Price).to receive(:where).with(
+        currency: 'EUR',
+        variant_id: 1001
+      ).and_return([price])
+
+      expect(price).to receive(:price_including_vat_for).and_return(12)
+    end
+
+    it do
+      line_item.price = 10
+      line_item.update_price
+      expect(line_item.price).to eq(12)
+    end
+  end
+end

--- a/spec/models/spree/line_item_decorator_spec.rb
+++ b/spec/models/spree/line_item_decorator_spec.rb
@@ -1,14 +1,15 @@
+# frozen_string_literal: true
 describe Spree::LineItem do
-  describe 'update_price' do
-    let(:price)     { double 'price' }
-    let(:order)     { create :order, currency: 'EUR' }
-    let(:line_item) { create :line_item, order_id: order.id, currency: 'EUR' }
+  describe "update_price" do
+    let(:price)     { double "price" }
+    let(:order)     { create :order, currency: "EUR" }
+    let(:line_item) { create :line_item, order_id: order.id, currency: "EUR" }
 
     before do
       expect(line_item).to receive(:variant_id).and_return(1001)
 
       expect(Spree::Price).to receive(:where).with(
-        currency: 'EUR',
+        currency: "EUR",
         variant_id: 1001
       ).and_return([price])
 


### PR DESCRIPTION
Fix for https://github.com/spree-contrib/spree_multi_currency/issues/64

The issue seems to stem from the call to price_including_vat_for against the variant. This delegates the method onto it's price object, but from the variant it has no way to know whether the price is a EUR / USD object, it instead uses the Spree::Config[:currency] value to determine which price to use and comes back with the USD object instead of the EUR object.

Therefore I expect a change needs to be applied where this info is known, in the line_item.rb method update_price to get back the correct price object and invoke price_including_vat_for directly.
