### PR TITLE
Update supporting versions of spree and ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ env:
 
 language: ruby
 gemfile:
-  - gemfiles/spree_3_1.gemfile
   - gemfiles/spree_3_2.gemfile
-  - gemfiles/spree_3_3.gemfile
+  - gemfiles/spree_3_5.gemfile
+  - gemfiles/spree_3_6.gemfile
   - gemfiles/spree_master.gemfile
 
 script:
@@ -24,8 +24,9 @@ script:
   - bundle exec rake spec
 
 rvm:
-  - 2.3.1
-  - 2.2.7
+  - 2.5.1
+  - 2.4.4
+  - 2.3.7
 
 matrix:
     allow_failures:

--- a/Appraisals
+++ b/Appraisals
@@ -1,13 +1,13 @@
-appraise 'spree-3-1' do
-  gem 'spree', '~> 3.1.0'
-end
-
 appraise 'spree-3-2' do
   gem 'spree', '~> 3.2.0'
 end
 
-appraise 'spree-3-3' do
-  gem 'spree', '~> 3.3.0'
+appraise 'spree-3-5' do
+  gem 'spree', '~> 3.5.0'
+end
+
+appraise 'spree-3-6' do
+  gem 'spree', '~> 3.6.0'
 end
 
 appraise 'spree-master' do

--- a/gemfiles/spree_3_5.gemfile
+++ b/gemfiles/spree_3_5.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "spree", "~> 3.1.0"
+gem "spree", "~> 3.5.0"
 
 gemspec path: "../"

--- a/gemfiles/spree_3_6.gemfile
+++ b/gemfiles/spree_3_6.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "spree", "~> 3.3.0"
+gem "spree", "~> 3.6.0"
 
 gemspec path: "../"


### PR DESCRIPTION
Update supporting spree version to 3.2, 3.5, 3.6
Update ruby version to 2.3.7, 2.4.4, 2.5.1