### PR TITLE
Removed route doubled with one from spree/frontend

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,4 @@
 Spree::Core::Engine.add_routes do
-  get '/currency/set', to: 'currency#set', defaults: { format: :json }, as: :set_currency
-
   namespace :admin do
     resources :products do
       resources :prices, only: [:index, :create]


### PR DESCRIPTION
This route is already defined in spree: https://github.com/spree/spree/blob/master/frontend/config/routes.rb#L39. Causes an error: `Invalid route name, already in use: 'set_currency'  (ArgumentError)`